### PR TITLE
Fix project URL for PyPi

### DIFF
--- a/midi2poprap/setup.py
+++ b/midi2poprap/setup.py
@@ -7,7 +7,7 @@ setup(
     description = 'Convert midi to poprap png, the industry standard for bubble wrap music devices',
     author = 'Ken Seehart',
     author_email = 'ken@seehart.com',
-    url = 'https://github.com/kenseehart/midi2poprap/poprap',
+    url = 'https://github.com/kenseehart/midi2poprap/',
     download_url = 'https://github.com/kenseehart/midi2poprap/archive/refs/tags/v1.0.0.tar.gz',
     keywords = ['midi', 'bubblewrap'],
     classifiers = [],


### PR DESCRIPTION
Just stumbled upon your project on PyPi and the homepage link greeted me with a 404.
Here's a proposed fix for that.